### PR TITLE
Support setting root directory using FISHWEB_ROOT_DIR env var

### DIFF
--- a/src/fishweb/__init__.py
+++ b/src/fishweb/__init__.py
@@ -1,8 +1,10 @@
+import os
+from pathlib import Path
+
 from fishweb.app import DEFAULT_ROOT_DIR, create_fishweb_app
 
 app = create_fishweb_app(
-    bind_address="localhost:8888",  # TODO: get it from uvicorn?
-    root_dir=DEFAULT_ROOT_DIR,  # TODO: get it from argv?
+    root_dir=Path(os.getenv("FISHWEB_ROOT_DIR", DEFAULT_ROOT_DIR)),
 )
 
 __all__ = ("app",)

--- a/src/fishweb/app/app.py
+++ b/src/fishweb/app/app.py
@@ -14,9 +14,8 @@ DEFAULT_ROOT_DIR = Path.home() / "fishweb"
 
 
 class SubdomainMiddleware:
-    def __init__(self, app: ASGIApp, *, bind_address: str, root_dir: Path) -> None:
+    def __init__(self, app: ASGIApp, *, root_dir: Path) -> None:
         self.app = app
-        self.bind_address = bind_address
         self.root_dir = root_dir
         self.app_wrappers: dict[str, AppWrapper] = {}
 
@@ -40,12 +39,12 @@ class SubdomainMiddleware:
             return await self.app(scope, receive, send)
 
         request = Request(scope)
-        address = request.headers.get("host") or ""
-        subdomain = "www" if address == self.bind_address else address.split(".")[0]
+        hostname = request.url.hostname or ""
+        subdomain = "www" if "." not in hostname else hostname.split(".")[0]
         app_dir = self.root_dir / subdomain
 
         # Prevent requests outside of the root directory or to the root directory itself,
-        # e.g. "http://.localhost:8888"
+        # e.g. "http://.localhost"
         if app_dir.parent != self.root_dir:
             response = PlainTextResponse(
                 content=HTTPStatus.NOT_FOUND.phrase,
@@ -84,6 +83,6 @@ class SubdomainMiddleware:
         return await app(scope, receive, send)
 
 
-def create_fishweb_app(*, bind_address: str, root_dir: Path) -> Starlette:
-    middleware = (Middleware(SubdomainMiddleware, bind_address=bind_address, root_dir=root_dir),)
+def create_fishweb_app(*, root_dir: Path) -> Starlette:
+    middleware = (Middleware(SubdomainMiddleware, root_dir=root_dir),)
     return Starlette(middleware=middleware)

--- a/src/fishweb/cmd/serve.py
+++ b/src/fishweb/cmd/serve.py
@@ -17,10 +17,14 @@ serve_cli = Typer()
 
 @serve_cli.command()
 def serve(
-    bind_address: Annotated[
+    host: Annotated[
         str,
-        Option("--addr", "-a", help="bind address to listen on"),
-    ] = "localhost:8888",
+        Option("--host", "-h", help="host address to listen on"),
+    ] = "localhost",
+    port: Annotated[
+        int,
+        Option("--port", "-p", help="port number to listen on"),
+    ] = 8888,
     root_dir: Annotated[
         Path,
         Option("--root", "-r", help="root directory to serve apps from"),
@@ -30,9 +34,8 @@ def serve(
     Start fishweb server
     """
     if uvicorn:
-        host, port = bind_address.split(":")
-        app = create_fishweb_app(bind_address=bind_address, root_dir=root_dir)
-        uvicorn.run(app, host=host, port=int(port))
+        app = create_fishweb_app(root_dir=root_dir)
+        uvicorn.run(app, host=host, port=port)
     else:
         print("Uvicorn is not installed.")
         print("Reinstall fishweb with the 'serve' extra to use this command.")


### PR DESCRIPTION
- also removed hostname parameter from middleware because it is unnecessary
- split bind_address into host and port for serve command