### PR TITLE
Allow nested subdomains

### DIFF
--- a/examples/nested.sub/main.py
+++ b/examples/nested.sub/main.py
@@ -1,0 +1,10 @@
+async def app(scope, receive, send):
+    assert scope["type"] == "http"
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [[b"content-type", b"text/plain"]],
+        },
+    )
+    await send({"type": "http.response.body", "body": b"Served from a nested subdomain."})

--- a/src/fishweb/app/middleware.py
+++ b/src/fishweb/app/middleware.py
@@ -16,6 +16,22 @@ from fishweb.logging import GLOBAL_LOG_FORMAT, app_logging_filter
 DEFAULT_ROOT_DIR = Path.home() / "fishweb"
 
 
+def extract_subdomain(hostname: str, /) -> str:
+    """Attempt to extract the subdomain from a hostname, including nested subdomains.
+
+    The last two segments are removed, unless the last segment is `localhost`,
+    in which case only the last segment is removed.
+    If there is no subdomain, `www` is returned.
+    """
+    segments = hostname.split(".")
+    # TODO(lemonyte): Take into account other domain configurations, such as `domain.co.uk`.
+    # This should be done by using a user-configured domain that will be used to split the hostname.
+    root_levels = 2
+    if segments[-1] == "localhost":
+        root_levels = 1
+    return "www" if len(segments) == root_levels else ".".join(segments[:-root_levels])
+
+
 class SubdomainMiddleware:
     def __init__(self, app: ASGIApp, *, root_dir: Path, reload: bool = False) -> None:
         self.app = app
@@ -49,7 +65,7 @@ class SubdomainMiddleware:
 
         request = Request(scope)
         hostname = request.url.hostname or ""
-        subdomain = "www" if "." not in hostname else hostname.split(".")[0]
+        subdomain = extract_subdomain(hostname)
         app_dir = self.root_dir / subdomain
         self.logger.debug(f"handling request for subdomain '{subdomain}' on hostname '{hostname}'")
 


### PR DESCRIPTION
- Fixes #19 

Note: at the moment this only works for `localhost` and domains with exactly 1 TLD segment, like `example.com`.
For cases like `example.co.uk` or running Fishweb on a subdomain, a user-configured domain setting is required